### PR TITLE
Replace ''contexts' with 'scopes'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ The `inventory` service is built in a similar way.
 === What is CDI?
 
 Contexts and Dependency Injection (CDI) defines a rich set of complementary services that improve the application structure.
-The most fundamental services that are provided by CDI are contexts that bind the lifecycle of stateful components to well-defined contexts,
+The most fundamental services that are provided by CDI are scopes that bind the lifecycle of stateful components to well-defined contexts,
 and dependency injection that is the ability to inject components into an application in a typesafe way.
 With CDI, the container does all the daunting work of instantiating dependencies, and
 controlling exactly when and how these components are instantiated and destroyed.


### PR DESCRIPTION
Replaced 'contexts' with 'scopes' in line 56.

I'm working on an article on CDI's and using this resource as a reference. Just noticed that the term 'contexts' and would like to suggest that 'scopes' might be a more appropriate term here. Please advise.