### PR TITLE
removed jdk 9 support dependency

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -60,13 +60,6 @@
             <version>1.1.4</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -60,13 +60,6 @@
             <version>1.1.4</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
- Addressed issues outlined here: https://github.com/OpenLiberty/guides-common/issues/459
- Tested end-to-end
- Tested with jdk 11.0.7
- Tested with openjdk64-1.8.0.252