### PR TITLE
Fix for allowing the action to be triggered by an empty commit

### DIFF
--- a/.github/workflows/triggerConversion.yml
+++ b/.github/workflows/triggerConversion.yml
@@ -7,11 +7,6 @@ on:
     branches:
       - 'master'
       - 'qa'
-    paths:
-      - 'README.adoc'
-      - 'start/**'
-      - 'finish/**'
-      - 'assets/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Removed code is responsible for only being triggered when there is a change to one of those files/directories.