### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,12 +71,14 @@ include::{common-includes}/gitclone.adoc[]
 [role='command']
 include::{common-includes}/twyb-intro.adoc[]
 
-Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL. This is the starting point of the `inventory`
-service and it displays the current contents of the inventory. As you might expect, these are empty since
-nothing is stored in the inventory yet. Next, point your browser to the http://localhost:9080/inventory/systems/localhost[http://localhost:9080/inventory/systems/localhost^] URL.
+Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL.
+This is the starting point of the `inventory` service and it displays the current contents of the inventory. 
+As you might expect, these are empty since nothing is stored in the inventory yet. 
+Next, point your browser to the http://localhost:9080/inventory/systems/localhost[http://localhost:9080/inventory/systems/localhost^] URL.
 You see a result in JSON format with the system properties of your local JVM. When you visit this URL, these system
-properties are automatically stored in the inventory. Go back to http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] and
-you see a new entry for `localhost`. For simplicity, only the OS name and username are shown here for
+properties are automatically stored in the inventory. 
+Go back to http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] 
+and you see a new entry for `localhost`. For simplicity, only the OS name and username are shown here for
 each host. You can repeat this process for your own hostname or any other machine that is running
 the `system` service.
 


### PR DESCRIPTION
restructure the url sentences better so that the cloud-hosted guide can be converted the url with curl command correctly