### PR TITLE
Fix improper client closing in SystemClient class

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -1,13 +1,12 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2022 IBM Corporation and others.
+ * Copyright (c) 2017, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * http://www.eclipse.org/legal/epl-2.0/
  *
- * Contributors:
- *     IBM Corporation - Initial implementation
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
 // end::copyright[]
 package io.openliberty.guides.inventory.client;

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -40,8 +40,13 @@ public class SystemClient {
   public Properties getProperties(String hostname) {
     String url = buildUrl(
       PROTOCOL, hostname, Integer.valueOf(SYS_HTTP_PORT), SYSTEM_PROPERTIES);
-    Builder clientBuilder = buildClientBuilder(url);
-    return getPropertiesHelper(clientBuilder);
+    Client client = ClientBuilder.newClient();
+    try {
+      Builder clientBuilder = buildClientBuilder(url, client);
+      return getPropertiesHelper(clientBuilder);
+    } finally {
+      client.close();
+    }
   }
 
   // tag::doc[]
@@ -69,9 +74,8 @@ public class SystemClient {
   }
 
   // Method that creates the client builder
-  protected Builder buildClientBuilder(String urlString) {
+  protected Builder buildClientBuilder(String urlString, Client client) {
     try {
-      Client client = ClientBuilder.newClient();
       Builder builder = client.target(urlString).request();
       return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     } catch (Exception e) {

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -27,48 +27,49 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class SystemClient {
 
-  // Constants for building URI to the system service.
-  private final String SYSTEM_PROPERTIES = "/system/properties";
-  private final String PROTOCOL = "http";
+    // Constants for building URI to the system service.
+    private final String SYSTEM_PROPERTIES = "/system/properties";
+    private final String PROTOCOL = "http";
 
-  @Inject
-  @ConfigProperty(name = "system.http.port")
-  String SYS_HTTP_PORT;
+    @Inject
+    @ConfigProperty(name = "system.http.port")
+    String SYS_HTTP_PORT;
 
-  // Wrapper function that gets properties
-  public Properties getProperties(String hostname) {
-    Properties properties = null;
-    Client client = ClientBuilder.newClient();
-    try {
-      Builder builder = getBuilder(hostname, client);
-      properties = getPropertiesHelper(builder);
-    } catch (Exception e) {
-      System.err.println(
-        "Exception thrown while getting properties: " + e.getMessage());
-    } finally {
-      client.close();
+    // Wrapper function that gets properties
+    public Properties getProperties(String hostname) {
+        Properties properties = null;
+        Client client = ClientBuilder.newClient();
+        try {
+            Builder builder = getBuilder(hostname, client);
+            properties = getPropertiesHelper(builder);
+        } catch (Exception e) {
+            System.err.println(
+            "Exception thrown while getting properties: " + e.getMessage());
+        } finally {
+            client.close();
+        }
+        return properties;
     }
-    return properties;
-  }
 
-  // Method that creates the client builder
-  private Builder getBuilder(String hostname, Client client) throws Exception {
-    URI uri = new URI(
-      PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
-      SYSTEM_PROPERTIES, null, null);
-    String urlString = uri.toString();
-    Builder builder = client.target(urlString).request();
-    return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-  }
-
-  // Helper method that processes the request
-  private Properties getPropertiesHelper(Builder builder) throws Exception {
-    Response response = builder.get();
-    if (response.getStatus() == Status.OK.getStatusCode()) {
-      return response.readEntity(Properties.class);
-    } else {
-      System.err.println("Response Status is not OK.");
-      return null;
+    // Method that creates the client builder
+    private Builder getBuilder(String hostname, Client client) throws Exception {
+        URI uri = new URI(
+                      PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
+                      SYSTEM_PROPERTIES, null, null);
+        String urlString = uri.toString();
+        Builder builder = client.target(urlString).request();
+        builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        return builder;
     }
-  }
+
+    // Helper method that processes the request
+    private Properties getPropertiesHelper(Builder builder) throws Exception {
+        Response response = builder.get();
+        if (response.getStatus() == Status.OK.getStatusCode()) {
+            return response.readEntity(Properties.class);
+        } else {
+            System.err.println("Response Status is not OK.");
+            return null;
+        }
+    }
 }

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -52,37 +52,23 @@ public class SystemClient {
   }
 
   // Method that creates the client builder
-  protected Builder getBuilder(String hostname, Client client) throws Exception {
-    try {
-      URI uri = new URI(
-        PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
-        SYSTEM_PROPERTIES, null, null);
-      String urlString = uri.toString();
-      Builder builder = client.target(urlString).request();
-      return builder.header(HttpHeaders.CONTENT_TYPE,
-                            MediaType.APPLICATION_JSON);
-    } catch (Exception e) {
-      System.err.println(
-        "Exception thrown while building the client: " + e.getMessage());
-      return null;
-    }
+  private Builder getBuilder(String hostname, Client client) throws Exception {
+    URI uri = new URI(
+      PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
+      SYSTEM_PROPERTIES, null, null);
+    String urlString = uri.toString();
+    Builder builder = client.target(urlString).request();
+    return builder.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
   }
 
   // Helper method that processes the request
-  protected Properties getPropertiesHelper(Builder builder) {
-    try {
-      Response response = builder.get();
-      if (response.getStatus() == Status.OK.getStatusCode()) {
-        return response.readEntity(Properties.class);
-      } else {
-        System.err.println("Response Status is not OK.");
-      }
-    } catch (RuntimeException e) {
-      System.err.println("Runtime exception: " + e.getMessage());
-    } catch (Exception e) {
-      System.err.println(
-        "Exception thrown while invoking the request: " + e.getMessage());
+  private Properties getPropertiesHelper(Builder builder) throws Exception {
+    Response response = builder.get();
+    if (response.getStatus() == Status.OK.getStatusCode()) {
+      return response.readEntity(Properties.class);
+    } else {
+      System.err.println("Response Status is not OK.");
+      return null;
     }
-    return null;
   }
 }

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -42,13 +42,14 @@ public class SystemClient {
     try {
       // Build the URL
       URI uri = new URI(
-        PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT), 
+        PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
         SYSTEM_PROPERTIES, null, null);
       String url = uri.toString();
 
       // Create the client builder
       Builder builder = client.target(url).request()
-                              .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+                              .header(HttpHeaders.CONTENT_TYPE,
+                                      MediaType.APPLICATION_JSON);
 
       // Process the request
       Response response = builder.get();
@@ -58,7 +59,8 @@ public class SystemClient {
         System.err.println("Response Status is not OK.");
       }
     } catch (Exception e) {
-      System.err.println("Exception thrown while getting properties: " + e.getMessage());
+      System.err.println(
+        "Exception thrown while getting properties: " + e.getMessage());
     } finally {
       client.close();
     }

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -40,24 +40,8 @@ public class SystemClient {
     Properties properties = null;
     Client client = ClientBuilder.newClient();
     try {
-      // Build the URL
-      URI uri = new URI(
-        PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
-        SYSTEM_PROPERTIES, null, null);
-      String url = uri.toString();
-
-      // Create the client builder
-      Builder builder = client.target(url).request()
-                              .header(HttpHeaders.CONTENT_TYPE,
-                                      MediaType.APPLICATION_JSON);
-
-      // Process the request
-      Response response = builder.get();
-      if (response.getStatus() == Status.OK.getStatusCode()) {
-        properties = response.readEntity(Properties.class);
-      } else {
-        System.err.println("Response Status is not OK.");
-      }
+      Builder builder = getBuilder(hostname, client);
+      properties = getPropertiesHelper(builder);
     } catch (Exception e) {
       System.err.println(
         "Exception thrown while getting properties: " + e.getMessage());
@@ -65,5 +49,40 @@ public class SystemClient {
       client.close();
     }
     return properties;
+  }
+
+  // Method that creates the client builder
+  protected Builder getBuilder(String hostname, Client client) throws Exception {
+    try {
+      URI uri = new URI(
+        PROTOCOL, null, hostname, Integer.valueOf(SYS_HTTP_PORT),
+        SYSTEM_PROPERTIES, null, null);
+      String urlString = uri.toString();
+      Builder builder = client.target(urlString).request();
+      return builder.header(HttpHeaders.CONTENT_TYPE,
+                            MediaType.APPLICATION_JSON);
+    } catch (Exception e) {
+      System.err.println(
+        "Exception thrown while building the client: " + e.getMessage());
+      return null;
+    }
+  }
+
+  // Helper method that processes the request
+  protected Properties getPropertiesHelper(Builder builder) {
+    try {
+      Response response = builder.get();
+      if (response.getStatus() == Status.OK.getStatusCode()) {
+        return response.readEntity(Properties.class);
+      } else {
+        System.err.println("Response Status is not OK.");
+      }
+    } catch (RuntimeException e) {
+      System.err.println("Runtime exception: " + e.getMessage());
+    } catch (Exception e) {
+      System.err.println(
+        "Exception thrown while invoking the request: " + e.getMessage());
+    }
+    return null;
   }
 }


### PR DESCRIPTION
- Fix the warning: 
  ```
   [WARNING ] RESTEASY004687: Closing a class org.jboss.resteasy.client.jaxrs.engines.ManualClosingApacheHttpClient43Engine$CleanupAction instance for you. Please close clients yourself.
   ```
  - Fix improper client closing in `SystemClient.java`
  - Moves the client's lifecycle management outside the buildClientBuilder method, ensuring that the client is closed after it's no longer needed and preventing potential issues when using the Builder after the Client has been closed.